### PR TITLE
Support editing final commit messages

### DIFF
--- a/src/package_update.py
+++ b/src/package_update.py
@@ -61,6 +61,8 @@ class PackageUpdate(GObject.Object):
     __gtype_name__ = "PackageUpdate"
 
     subject_gvariant = GObject.Property(type=GObject.TYPE_VARIANT)
+    commit_message_is_edited = GObject.Property(type=bool, default=False)
+    editing_stack_page = GObject.Property(type=str, default="not-editing")
     final_commit_message_rich = GObject.Property(type=str)
 
     def __init__(self, subject: str, commits: List[Ggit.Commit], **kwargs):
@@ -88,6 +90,15 @@ class PackageUpdate(GObject.Object):
             target_property="final-commit-message-rich",
             flags=GObject.BindingFlags.SYNC_CREATE,
             transform_to=lambda message: linkify_html(message),
+        )
+
+        bind_property_full(
+            source=self,
+            source_property="commit-message-is-edited",
+            target=self,
+            target_property="editing-stack-page",
+            flags=GObject.BindingFlags.SYNC_CREATE,
+            transform_to=lambda editing: "editing" if editing else "not-editing",
         )
 
     def add_commit(self, commit: Ggit.Commit) -> None:

--- a/src/update-details.ui
+++ b/src/update-details.ui
@@ -57,6 +57,50 @@
 						</binding>
 					</object>
 				</child>
+				<property name="header-suffix">
+					<object class="GtkStack">
+						<binding name="visible-child-name">
+							<lookup name="editing-stack-page">
+								<lookup name="update">UpdateDetails</lookup>
+							</lookup>
+						</binding>
+						<child>
+							<object class="GtkStackPage">
+								<property name="name">not-editing</property>
+								<property name="child">
+									<object class="GtkButton">
+										<property name="halign">end</property>
+										<property name="action-name">win.edit-commit-message</property>
+										<binding name="action-target">
+											<lookup name="subject_gvariant">
+												<lookup name="update">UpdateDetails</lookup>
+											</lookup>
+										</binding>
+										<property name="child">
+											<object class="AdwButtonContent">
+												<property name="icon-name">edit-symbolic</property>
+												<property name="label" translatable="yes">Edit</property>
+											</object>
+										</property>
+										<style>
+											<class name="flat"/>
+										</style>
+									</object>
+								</property>
+							</object>
+						</child>
+						<child>
+							<object class="GtkStackPage">
+								<property name="name">editing</property>
+								<property name="child">
+									<object class="GtkLabel">
+										<property name="label" translatable="yes">Currently editing</property>
+									</object>
+								</property>
+							</object>
+						</child>
+					</object>
+				</property>
 			</object>
 		</child>
 		<child>


### PR DESCRIPTION
With the caveat that only a few editors are supported and the git auto-squashing annoyingly [treats amend commits as if they were squash commits](https://github.com/jtojnar/nonemast/issues/2).
