### PR TITLE
tests: Use pytest-tap

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -18,11 +18,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1659753918,
-        "narHash": "sha256-EsAYsT9BmKA4DBsFYANyWSRe6DGJg9rr6/5fgXrq9Dc=",
+        "lastModified": 1659968593,
+        "narHash": "sha256-/gb0PxLDdP1DgDpIoL1NAa6k10oruyBOHmPTeDV+/Uk=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "998bc5d86c7263a8de4208af97fe6d8f25c91956",
+        "rev": "511b224feddcdef1de58619c0bfda4bd9924252b",
         "type": "github"
       },
       "original": {
@@ -41,11 +41,11 @@
     },
     "utils": {
       "locked": {
-        "lastModified": 1656928814,
-        "narHash": "sha256-RIFfgBuKz6Hp89yRr7+NR5tzIAbn52h8vT6vXkYjZoM=",
+        "lastModified": 1659877975,
+        "narHash": "sha256-zllb8aq3YO3h8B/U0/J1WBgAL8EX5yWf5pMj3G0NAmc=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "7e2a3b3dfd9af950a856d66b0a7d01e3c18aa249",
+        "rev": "c0e246b9b83f637f4681389ecabcb2681b4f3af0",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -88,6 +88,7 @@
           checkInputs = with final.python3.pkgs; [
             final.git
             pytest
+            pytest-tap
           ];
 
           doCheck = true;

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -4,11 +4,22 @@
 tests_enabled = get_option('tests')
 pytest = find_program('py.test', required: tests_enabled)
 find_program('git', required: tests_enabled)
+python.find_installation(
+  'python3',
+  modules: [
+    'pytest_tap',
+  ],
+  required: tests_enabled,
+)
 
 if pytest.found()
   test(
     'Unit tests',
     pytest,
+    args: [
+      '--tap-stream',
+    ],
+    protocol: 'tap',
     workdir: meson.project_source_root(),
   )
 endif


### PR DESCRIPTION
This will make Meson aware of the individual tests.

Depends on https://github.com/NixOS/nixpkgs/pull/185668

Unfortunately, pytest-tap obscures errors during test collection: https://github.com/python-tap/pytest-tap/issues/30
