### PR TITLE
Fix updating final commit message when marking as reviewed

### DIFF
--- a/src/package_update.py
+++ b/src/package_update.py
@@ -105,7 +105,8 @@ class PackageUpdate(GObject.Object):
         self._commits.append(CommitInfo(commit=commit))
 
         subject, *msg_lines = commit.get_message().splitlines()
-        old_message_lines = self._message_lines
+        # Clone list so we can detect changes.
+        old_message_lines = list(self._message_lines)
         if subject.startswith("fixup! "):
             return
         elif subject.startswith("amend! "):


### PR DESCRIPTION
Assignment operator appears to copy the reference to a list so we were also modifying `old_message_lines` we wanted to use for change detection.
