### PR TITLE
Draft: Port to AdwNavigationSplitView

### DIFF
--- a/src/nonemast/update-item.blp
+++ b/src/nonemast/update-item.blp
@@ -10,6 +10,7 @@ template ListItem {
     orientation: horizontal;
 
     Label {
+      wrap: true;
       xalign: 0;
       label: bind template.item as <$PackageUpdate>.subject;
     }

--- a/src/nonemast/window.blp
+++ b/src/nonemast/window.blp
@@ -2,165 +2,166 @@ using Gtk 4.0;
 using Adw 1;
 
 template $NonemastWindow: Adw.ApplicationWindow {
-  default-width: 780;
-  default-height: 420;
+  title: _('Not Nearly Enough Masking Tape');
+  default-width: 850;
+  default-height: 500;
+  width-request: 850;
+  height-request: 500;
 
-  Adw.Leaflet leaflet {
-    can-navigate-back: true;
+  Adw.Breakpoint {
+    // Does not really support responsive yet https://github.com/jtojnar/nonemast/issues/7
+    condition ("max-width: 0sp")
 
-    Box {
-      orientation: vertical;
+    setters {
+      split_view.collapsed: true;
+    }
+  }
 
-      Adw.HeaderBar {
-        show-end-title-buttons: bind leaflet.folded;
+  Adw.NavigationSplitView split_view {
+    min-sidebar-width: 350;
 
-        title-widget: Adw.WindowTitle {
-          title: _('Not Nearly Enough Masking Tape');
-        };
+    sidebar: Adw.NavigationPage {
+      title: _('Commits');
 
-        ToggleButton {
-          active: bind search_bar.search-mode-enabled bidirectional;
-          focus-on-click: false;
-          icon-name: 'edit-find-symbolic';
-          tooltip-text: _('Search');
+      child: Adw.ToolbarView {
+        [top]
+        Adw.HeaderBar {
+          title-widget: Adw.WindowTitle {};
+
+          ToggleButton {
+            active: bind search_bar.search-mode-enabled bidirectional;
+            focus-on-click: false;
+            icon-name: 'edit-find-symbolic';
+            tooltip-text: _('Search');
+          }
+
+          MenuButton {
+            icon-name: 'funnel-symbolic';
+            menu-model: filter-menu;
+            tooltip-text: _('Filter');
+          }
+
+          [end]
+          MenuButton {
+            icon-name: 'open-menu-symbolic';
+            menu-model: primary_menu;
+          }
         }
 
-        MenuButton {
-          icon-name: 'funnel-symbolic';
-          menu-model: filter-menu;
-          tooltip-text: _('Filter');
-        }
+        content: Stack updates_list_stack {
+          StackPage {
+            name: 'loading';
 
-        [end]
-        MenuButton {
-          icon-name: 'open-menu-symbolic';
-          menu-model: primary_menu;
-        }
-      }
+            child: Box {
+              orientation: vertical;
+              spacing: 12;
+              valign: center;
 
-      Stack updates_list_stack {
-        StackPage {
-          name: 'loading';
+              Spinner {
+                width-request: 32;
+                height-request: 32;
+                spinning: true;
+              }
 
-          child: Box {
-            orientation: vertical;
-            spacing: 12;
-            valign: center;
+              Label {
+                label: _('Loading commits…');
+              }
+            };
+          }
 
-            Spinner {
-              width-request: 32;
-              height-request: 32;
-              spinning: true;
-            }
+          StackPage {
+            name: 'error';
 
-            Label {
-              label: _('Loading commits…');
-            }
-          };
-        }
+            child: Adw.StatusPage updates_list_error {
+              icon-name: 'face-uncertain-symbolic';
+              title: _('Error obtaining commit list.');
+            };
+          }
 
-        StackPage {
-          name: 'error';
+          StackPage {
+            name: 'list';
 
-          child: Adw.StatusPage updates_list_error {
-            icon-name: 'face-uncertain-symbolic';
-            title: _('Error obtaining commit list.');
-          };
-        }
+            child: Box {
+              orientation: vertical;
 
-        StackPage {
-          name: 'list';
+              SearchBar search_bar {
+                key-capture-widget: template;
 
-          child: Box {
-            orientation: vertical;
+                SearchEntry search_entry {
+                  search-changed => $on_search_changed();
 
-            SearchBar search_bar {
-              key-capture-widget: template;
-
-              SearchEntry search_entry {
-                search-changed => $on_search_changed();
-
-                accessibility {
-                  controls: updates_list_view;
+                  accessibility {
+                    controls: updates_list_view;
+                  }
                 }
               }
-            }
 
-            ScrolledWindow {
+              ScrolledWindow {
+                hexpand: false;
+                vexpand: true;
+
+                ListView updates_list_view {
+                  styles [
+                    "navigation-sidebar",
+                  ]
+
+                  show-separators: true;
+
+                  factory: BuilderListItemFactory {
+                    resource: '/cz/ogion/Nonemast/update-item.ui';
+                  };
+
+                  model: SingleSelection {
+                    notify::selected-item => $on_selected_item_changed();
+
+                    model: FilterListModel updates_filter_model {
+                      filter: updates_search_filter;
+                      model: bind template.updates;
+                    };
+                  };
+                }
+              }
+            };
+          }
+        };
+      };
+    };
+
+    content: Adw.NavigationPage {
+      title: _('Not Nearly Enough Masking Tape');
+
+      child: Adw.ToolbarView {
+        [top]
+        Adw.HeaderBar {}
+
+        content: Stack details_stack {
+          StackPage {
+            name: 'no-update-selected';
+
+            child: Adw.StatusPage {
+              title: _('No updates selected.');
+            };
+          }
+
+          StackPage {
+            name: 'details';
+
+            child: ScrolledWindow {
               hexpand: false;
               vexpand: true;
               hscrollbar-policy: never;
 
-              ListView updates_list_view {
-                show-separators: true;
-
-                factory: BuilderListItemFactory {
-                  resource: '/cz/ogion/Nonemast/update-item.ui';
-                };
-
-                model: SingleSelection {
-                  notify::selected-item => $on_selected_item_changed();
-
-                  model: FilterListModel updates_filter_model {
-                    filter: updates_search_filter;
-                    model: bind template.updates;
-                  };
-                };
+              $UpdateDetails update_details {
+                margin-top: '12';
+                margin-bottom: '12';
+                margin-start: '12';
+                margin-end: '12';
               }
-            }
-          };
-        }
-      }
-    }
-
-    Adw.LeafletPage {
-      navigatable: false;
-
-      child: Separator {};
-    }
-
-    Box {
-      orientation: vertical;
-      hexpand: true;
-
-      Adw.HeaderBar {
-        show-start-title-buttons: bind leaflet.folded;
-
-        Button {
-          visible: bind leaflet.folded;
-          icon-name: 'go-previous-symbolic';
-        }
-
-        title-widget: Adw.WindowTitle {};
-      }
-
-      Stack details_stack {
-        StackPage {
-          name: 'no-update-selected';
-
-          child: Adw.StatusPage {
-            title: _('No updates selected.');
-          };
-        }
-
-        StackPage {
-          name: 'details';
-
-          child: ScrolledWindow {
-            hexpand: false;
-            vexpand: true;
-            hscrollbar-policy: never;
-
-            $UpdateDetails update_details {
-              margin-top: '12';
-              margin-bottom: '12';
-              margin-start: '12';
-              margin-end: '12';
-            }
-          };
-        }
-      }
-    }
+            };
+          }
+        };
+      };
+    };
   }
 }
 


### PR DESCRIPTION
Picked from [my fork](https://github.com/jtojnar/nonemast/compare/main...bobby285271:nonemast:main), does not actually support responsive yet (https://github.com/jtojnar/nonemast/issues/7). Review with hide white-space.

https://gnome.pages.gitlab.gnome.org/libadwaita/doc/main/migrating-to-breakpoints.html#replace-adwleaflet

<img src="https://github.com/jtojnar/nonemast/assets/20080233/88441f90-f83f-4061-94a5-ca933afa3e3a" width="60%">


