### PR TITLE
Allow overriding base commit with CLI argument

### DIFF
--- a/src/nonemast/main.py
+++ b/src/nonemast/main.py
@@ -15,6 +15,8 @@ from typing import Callable, Optional, Sequence, TypeVar
 class NonemastApplication(Adw.Application):
     """The main application singleton class."""
 
+    _base_revspec: Optional[str] = None
+
     def __init__(self, version: str):
         super().__init__(
             application_id="cz.ogion.Nonemast",
@@ -22,16 +24,37 @@ class NonemastApplication(Adw.Application):
         )
         Ggit.init()
         self.version = version
+        self._setup_commandline()
         self.create_action("quit", self.on_quit_action, ["<primary>q"])
         self.create_action("about", self.on_about_action)
+
+    def _setup_commandline(self):
+        self.add_main_option(
+            long_name="base-commit",
+            short_name=ord("b"),
+            flags=GLib.OptionFlags.NONE,
+            arg=GLib.OptionArg.STRING,
+            description="Revspec describing the first commit to include in the review (default: merge base between master and staging branches)",
+            arg_description="<rev>",
+        )
 
     def do_activate(self, repo_path: Optional[Gio.File] = None) -> None:
         win = self.props.active_window
         if not win:
             if repo_path is None:
                 repo_path = Gio.File.new_for_path(GLib.get_current_dir())
-            win = NonemastWindow(application=self, repo_path=repo_path)
+            win = NonemastWindow(
+                application=self,
+                repo_path=repo_path,
+                base_revspec=self._base_revspec,
+            )
         win.present()
+
+    def do_handle_local_options(self, options: GLib.VariantDict) -> int:
+        if (base_revspec := options.lookup_value("base-commit")) is not None:
+            self._base_revspec = base_revspec.get_string()
+
+        return -1
 
     def do_open(self, files: Sequence[Gio.File], n_files: int, hint: str) -> None:
         if n_files != 1:


### PR DESCRIPTION
The app now allows passing refspec (see `man gitrevisions`) of the base commit through `-b` or `--base-commit` CLI argument.
