### PR TITLE
Port to AdwAboutDialog

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -18,11 +18,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1712449641,
-        "narHash": "sha256-U9DDWMexN6o5Td2DznEgguh8TRIUnIl9levmit43GcI=",
+        "lastModified": 1731763621,
+        "narHash": "sha256-ddcX4lQL0X05AYkrkV2LMFgGdRvgap7Ho8kgon3iWZk=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "600b15aea1b36eeb43833a50b0e96579147099ff",
+        "rev": "c69a9bffbecde46b4b939465422ddc59493d3e4d",
         "type": "github"
       },
       "original": {
@@ -59,11 +59,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1710146030,
-        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
         "type": "github"
       },
       "original": {

--- a/meson.build
+++ b/meson.build
@@ -30,7 +30,7 @@ blueprint_compiler = find_program(
 )
 
 dependency('gtk4', version: '>= 4.6.0')
-dependency('libadwaita-1', version: '>= 1.2.alpha')
+dependency('libadwaita-1', version: '>= 1.5.0')
 dependency('libgit2-glib-1.0', version: ['>= 1.0.0'])
 
 nonemast_prefix = get_option('prefix')

--- a/src/nonemast/main.py
+++ b/src/nonemast/main.py
@@ -75,8 +75,7 @@ class NonemastApplication(Adw.Application):
         _parameter: None,
     ) -> None:
         """Callback for the app.about action."""
-        about = Adw.AboutWindow(
-            transient_for=self.props.active_window,
+        about = Adw.AboutDialog(
             application_name="Not Nearly Enough Masking Tape",
             application_icon="cz.ogion.Nonemast",
             license_type=Gtk.License.MIT_X11,
@@ -84,7 +83,7 @@ class NonemastApplication(Adw.Application):
             developers=["Jan Tojnar"],
             copyright="© 2022 Jan Tojnar",
         )
-        about.present()
+        about.present(self.props.active_window)
 
     T = TypeVar("T", bound=GLib.Variant | None)
 


### PR DESCRIPTION
https://gnome.pages.gitlab.gnome.org/libadwaita/doc/main/migrating-to-adaptive-dialogs.html#port-adwaboutwindow-to-adwaboutdialog

`AdwAboutDialog` is introduced in 1.5 and `AdwAboutWindow` is deprecated in 1.6.